### PR TITLE
Move store creation before user defined middleware

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -15,9 +15,9 @@ export default compose([
     ),
     conditional(),
     etag(),
+    storeCreator(),
     ...appMiddlewares,
     staticAssetsServer(),
-    storeCreator(),
     router(),
     renderer(),
 ]);


### PR DESCRIPTION
If there is no reason to keep the store creation after the user defined middlewares, I think we could move it before.

For example in my app, I wanted to populate the state before the render.