### PR TITLE
[Breaking] Remove init and add a dispatchAction function

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,11 @@
             "experimentalObjectRestSpread": true
         }
     },
+    "globals": {
+        "IS_CLIENT": false,
+        "IS_SERVER": false,
+    },
+
     "rules": {
         // We use 4 space indent at Evaneos
         "indent": [2, 4],

--- a/config/build/babelrc.js
+++ b/config/build/babelrc.js
@@ -1,12 +1,11 @@
 import { vitaminResolve } from '../utils';
 export default (env) => ({
     presets: [
-        ...(env === 'client' ?
-            ['es2015'] :
-            ['es2015-node5']
+        (env === 'client' ?
+            ['es2015', { modules: false }] :
+            'es2015-node5'
         ),
-        'react',
-        'stage-1',
+        'react', 'stage-1',
     ],
     plugins: [
         // Make optional the explicit import of React in JSX files

--- a/config/build/webpack.config.client.js
+++ b/config/build/webpack.config.client.js
@@ -29,6 +29,8 @@ function clientConfig(options, entryName, entryPath) {
             ] : []),
             new webpack.DefinePlugin({
                 'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+                IS_CLIENT: true,
+                IS_SERVER: false,
             }),
         ],
     }, concat);

--- a/config/build/webpack.config.common.js
+++ b/config/build/webpack.config.common.js
@@ -1,6 +1,6 @@
 import { vitaminResolve, appResolve } from '../utils';
 import appConfig, { moduleMap } from '../index';
-import { HotModuleReplacementPlugin, LoaderOptionsPlugin } from 'webpack';
+import { HotModuleReplacementPlugin, LoaderOptionsPlugin, NamedModulesPlugin } from 'webpack';
 import autoprefixer from 'autoprefixer';
 import babelrc from './babelrc';
 
@@ -76,6 +76,7 @@ export function config(options) {
         plugins: [
             ...(options.hot ? [
                 new HotModuleReplacementPlugin(),
+                new NamedModulesPlugin(),
                 new LoaderOptionsPlugin({
                     test: /\.css$/,
                     debug: true,

--- a/config/build/webpack.config.server.js
+++ b/config/build/webpack.config.server.js
@@ -64,6 +64,8 @@ module.exports = function serverConfig(options) {
             })] : []),
             new DefinePlugin({
                 __VITAMIN__CLIENT_BUNDLE_VERSION__: `'${options.hash || ''}'`,
+                IS_CLIENT: false,
+                IS_SERVER: true,
             }),
         ],
     }, concat);

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -8,6 +8,7 @@ export default {
         basePath: '',
         externalUrl: '',
         layout: '__vitamin__/src/server/components/HtmlLayout',
+        actionDispatcher: '__vitamin__/config/utils/defaultFunction',
     },
     routes: '__vitamin__/config/utils/emptyArray',
     redux: {

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -40,8 +40,5 @@ export default {
         },
     },
 
-    // TODO REFACTOR, I DONT LIKE THIS
-    init: '__vitamin__/config/utils/identityFunction',
-    renderFullPage: true,
     rootElementId: 'vitamin-app',
 };

--- a/config/index.js
+++ b/config/index.js
@@ -116,7 +116,6 @@ const modulePaths = [
     ['redux', 'middlewares'],
     ['redux', 'enhancers'],
     ['redux', 'state', 'serializer'],
-    ['init'],
 ];
 
 export const moduleMap = getModuleMap(modulePaths);

--- a/config/index.js
+++ b/config/index.js
@@ -112,6 +112,7 @@ const modulePaths = [
     ['server', 'Error404Page'],
     ['server', 'Error500Page'],
     ['server', 'layout'],
+    ['server', 'actionDispatcher'],
     ['redux', 'reducers'],
     ['redux', 'middlewares'],
     ['redux', 'enhancers'],

--- a/config/utils/defaultFunction.js
+++ b/config/utils/defaultFunction.js
@@ -1,0 +1,1 @@
+export default () => {};

--- a/config/utils/emptyObject.js
+++ b/config/utils/emptyObject.js
@@ -1,0 +1,1 @@
+export default {};

--- a/config/utils/identityFunction.js
+++ b/config/utils/identityFunction.js
@@ -1,1 +1,0 @@
-export default (x = null) => x;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-dom": "^15.3.0"
   },
   "peerDependencies": {
-    "react": "^15.1.0",
+    "react": "^15.3.1",
     "react-router": "^2.5.1",
     "react-router-redux": "^4.0.5",
     "react-redux": "^4.4.5",
@@ -51,15 +51,15 @@
   "dependencies": {
     "async-props": "^0.3.2",
     "autoprefixer": "^6.3.3",
-    "babel-core": "^6.10.4",
+    "babel-core": "^6.14.0",
     "babel-eslint": "^6.1.0",
-    "babel-loader": "^6.2.2",
+    "babel-loader": "^6.2.5",
     "babel-plugin-react-require": "^2.1.0",
-    "babel-preset-es2015-node5": "^1.1.2",
-    "babel-preset-es2015": "^6.13.2",
-    "babel-preset-react": "^6.11.0",
-    "babel-preset-stage-1": "^6.3.13",
-    "babel-register": "^6.5.2",
+    "babel-preset-es2015": "^6.14.0",
+    "babel-preset-es2015-node5": "^1.2.0",
+    "babel-preset-react": "^6.11.1",
+    "babel-preset-stage-1": "^6.13.0",
+    "babel-register": "^6.14.0",
     "commander": "^2.9.0",
     "css-loader": "^0.23.1",
     "express": "^4.14.0",
@@ -84,8 +84,11 @@
     "strip-json-comments": "^2.0.1",
     "strip-json-comments-loader": "0.0.2",
     "url-loader": "^0.5.7",
-    "webpack": "^2.1.0-beta.4 || ^2.0.0",
+    "webpack": "^2.1.0-beta.21",
     "webpack-dev-middleware": "^1.5.1",
     "webpack-hot-middleware": "^2.11.0"
+  },
+  "engines": {
+    "node": ">=5.0.0"
   }
 }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -4,7 +4,6 @@ import { syncHistoryWithStore } from 'react-router-redux';
 import { createHistory } from 'history';
 import { create as createStore, createRootReducer } from '../shared/store';
 import config from '../../config';
-import init from '__app_modules__init__';
 import routes from '__app_modules__routes__';
 import reducers from '__app_modules__redux_reducers__';
 import middlewares from '__app_modules__redux_middlewares__';
@@ -42,9 +41,11 @@ function bootstrapClient() {
         );
 
     const syncedHistory = syncHistoryWithStore(history, store);
-    if (init instanceof Function) init(store);
     // Todo replace by vitamin-app-[hash] ?
     const appElement = document.getElementById(config.rootElementId);
+    const passStore = route => (
+        typeof route === 'function' ? route(store) : route
+    );
 
     if (module.hot) {
         const renderError = (error, rootEl) => {
@@ -63,13 +64,13 @@ function bootstrapClient() {
             const newRoutes = require('__app_modules__routes__').default;
             unmountComponentAtNode(appElement);
             try {
-                render(syncedHistory, store, newRoutes, appElement);
+                render(syncedHistory, store, passStore(newRoutes), appElement);
             } catch (e) {
                 renderError(e, appElement);
             }
         });
     }
-    render(syncedHistory, store, routes, appElement);
+    render(syncedHistory, store, passStore(routes), appElement);
 }
 
 bootstrapClient();

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -6,6 +6,7 @@ import renderer from './middlewares/renderer';
 import errorHandler from './middlewares/errorHandler';
 import storeCreator from './middlewares/store';
 import router from './middlewares/router';
+import actionDispatcher from './middlewares/actionDispatcher';
 import staticAssetsServer from './middlewares/staticAssetsServer';
 import appMiddlewares from '__app_modules__server_middlewares__';
 export default compose([
@@ -20,6 +21,7 @@ export default compose([
     ...appMiddlewares,
     staticAssetsServer(),
     storeCreator(),
+    actionDispatcher(),
     router(),
     renderer(),
 ]);

--- a/src/server/middlewares/actionDispatcher.js
+++ b/src/server/middlewares/actionDispatcher.js
@@ -1,0 +1,10 @@
+import actionDispatcher from '__app_modules__server_actionDispatcher__';
+
+export default () => function* actionDispatcherMiddleware(next) {
+    const { dispatch, getState } = this.state.store;
+    const dispatchResult = actionDispatcher(this.req, dispatch, getState);
+    if (dispatchResult) {
+        yield dispatchResult;
+    }
+    yield next;
+};

--- a/src/server/middlewares/router.js
+++ b/src/server/middlewares/router.js
@@ -1,16 +1,23 @@
 import { match } from 'react-router';
 import routes from '__app_modules__routes__';
 
+const routesWithStore = store => (
+    typeof routes === 'function' ? routes(store) : routes
+);
+
 export default () => function* routerMiddleware(next) {
     const url = this.req.url;
     const history = this.state.history;
-    match({ routes, location: url, history },
+
+    match({ routes: routesWithStore(this.state.store), location: url, history },
         (error, redirectLocation, renderProps) => {
             if (error) {
                 this.status = 500;
                 this.body = error.message;
             } else if (redirectLocation) {
-                this.redirect(redirectLocation.pathname + redirectLocation.search);
+                this.redirect(
+                    redirectLocation.basename + redirectLocation.pathname + redirectLocation.search
+                );
             } else if (renderProps) {
                 this.status = 200;
                 this.state.renderProps = renderProps;


### PR DESCRIPTION
### [Breaking] remove init from config. 

Now the store is can be passed to a function exported by routes. This is how we initialize things now. You can use IS_CLIENT if you want to do stuff only client-side. And @mdarse will be happy

### ActionDispatcher (close #11)

Add the possibility to specify an `actionDispatcher`, which will called on server before each request for initializing the store.
It is passed the node http request object, the dispatch function, and getState.
It's expected to return something that can be yield (Promise, Generator, etc..) or nothing.
If it returns a yieldable, then the server will wait its completion before continuing.

### Various stuff
- Update dependancies
- Add `emptyObject` file
- Add `IS_CLIENT` and `IS_SERVER` global booleans.