### PR TITLE
Add the ability to specify hash in client bundles

### DIFF
--- a/config/build/babelrc.js
+++ b/config/build/babelrc.js
@@ -1,16 +1,24 @@
 import { vitaminResolve } from '../utils';
-export default (env) => ({
+
+export default env => ({
     presets: [
         (env === 'client' ?
             ['es2015', { modules: false }] :
             'es2015-node6/object-rest'
         ),
-        'react',
-        'stage-1',
+        'react', 'es2016', 'es2017', 'stage-1',
     ],
     plugins: [
         // Make optional the explicit import of React in JSX files
         'react-require',
+        // Add Object.entries, Object.values and other ES2017 functionalities
+        ...(env === 'server' ?
+            ['transform-runtime'] :
+            // in the client, we prefer solution like https://polyfill.io/v2/docs/, to keep the
+            // bundle the smallest possible.
+            []
+        ),
+
     ],
     sourceRoot: vitaminResolve(),
 });

--- a/config/build/webpack.config.common.js
+++ b/config/build/webpack.config.common.js
@@ -6,13 +6,13 @@ import babelrc from './babelrc';
 
 const MODULES_DIRECTORIES = [appResolve('node_modules'), vitaminResolve('node_modules')];
 
-export const createBabelLoaderConfig = (env) => ({
+export const createBabelLoaderConfig = env => ({
     test: /\.js(x?)$/,
     loader: 'babel',
-    include: (path) =>
+    include: path =>
         path.indexOf('node_modules') === -1 ||
-        path.indexOf('node_modules/vitaminjs') !== -1 &&
-        path.indexOf('node_modules/vitaminjs/node_modules') === -1,
+        (path.indexOf('node_modules/vitaminjs') !== -1 &&
+        path.indexOf('node_modules/vitaminjs/node_modules') === -1),
     query: babelrc(env),
 });
 export function config(options) {
@@ -35,7 +35,7 @@ export function config(options) {
             wrappedContextRegExp: /$^/,
             wrappedContextCritical: true,
 
-            loaders: [{
+            rules: [{
                 // only files with .global will go through this loader
                 test: /\.global\.css$/,
                 loaders: [
@@ -70,16 +70,15 @@ export function config(options) {
             modules: MODULES_DIRECTORIES,
             extensions: ['.js', '.jsx', '.json', '.css'],
         },
-        postcss() {
-            return [autoprefixer];
-        },
         plugins: [
             ...(options.hot ? [
                 new HotModuleReplacementPlugin(),
                 new NamedModulesPlugin(),
                 new LoaderOptionsPlugin({
                     test: /\.css$/,
+                    context: __dirname,
                     debug: true,
+                    postcss: [autoprefixer],
                 }),
             ] : []),
         ],

--- a/config/build/webpack.config.js
+++ b/config/build/webpack.config.js
@@ -1,0 +1,5 @@
+import webpackConfigClient from './webpack.config.client';
+import webpackConfigServer from './webpack.config.server';
+
+export default options =>
+    [webpackConfigServer(options), webpackConfigClient(options)];

--- a/config/build/webpack.config.server.js
+++ b/config/build/webpack.config.server.js
@@ -1,9 +1,10 @@
-import { config, createBabelLoaderConfig } from './webpack.config.common';
-import { vitaminResolve, appResolve, concat } from '../utils';
 import { BannerPlugin, DefinePlugin } from 'webpack';
 import mergeWith from 'lodash.mergewith';
-import appConfig from '../index';
 import fs from 'fs';
+import { config, createBabelLoaderConfig } from './webpack.config.common';
+import { vitaminResolve, appResolve, concat } from '../utils';
+import appConfig from '../index';
+
 const safeReaddirSync = (path) => {
     try {
         return fs.readdirSync(path);
@@ -12,7 +13,7 @@ const safeReaddirSync = (path) => {
     }
 };
 
-const externalModules = (modulesPath) => safeReaddirSync(modulesPath).filter(m => m !== '.bin');
+const externalModules = modulesPath => safeReaddirSync(modulesPath).filter(m => m !== '.bin');
 const appModules = externalModules(appResolve('node_modules'));
 const vitaminModules = externalModules(vitaminResolve('node_modules'));
 const whiteList = ['webpack/hot/poll.js?1000'];
@@ -55,15 +56,15 @@ module.exports = function serverConfig(options) {
         },
 
         module: {
-            loaders: [createBabelLoaderConfig('server')],
+            rules: [createBabelLoaderConfig('server')],
         },
         plugins: [
             ...(options.dev ? [new BannerPlugin({
                 banner: 'require("source-map-support").install();',
-                raw: true, entryOnly: false,
+                raw: true,
+                entryOnly: false,
             })] : []),
             new DefinePlugin({
-                __VITAMIN__CLIENT_BUNDLE_VERSION__: `'${options.hash || ''}'`,
                 IS_CLIENT: false,
                 IS_SERVER: true,
             }),

--- a/examples/counter/Counter/index.jsx
+++ b/examples/counter/Counter/index.jsx
@@ -4,12 +4,12 @@ import { compose } from 'redux';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import s from './style.css';
 
-const Counter = ({ value, onIncrement, onDecrement }) => (
+const Counter = ({ value, onIncrement, onDecrement }) =>
     <div> Counter: <span className={s.value}>{value}</span> <br />
         <button className={s.button} onClick={onIncrement}> +1 </button>
         <button className={s.button} onClick={onDecrement}> -1 </button>
     </div>
-);
+;
 
 Counter.propTypes = {
     value: PropTypes.number.isRequired,
@@ -19,7 +19,7 @@ Counter.propTypes = {
 
 
 const mapStateToProps = ({ counter }) => ({ value: counter });
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
     onIncrement: () => dispatch({ type: 'INCREMENT' }),
     onDecrement: () => dispatch({ type: 'DECREMENT' }),
 });

--- a/examples/counter/routes.jsx
+++ b/examples/counter/routes.jsx
@@ -1,5 +1,5 @@
 import { Route } from 'react-router';
-import Counter from './Counter';
+import Counter from './Counter/index.jsx';
 
 export default (
     <Route component={Counter} path="/" />

--- a/examples/counter/webpack-assets.json
+++ b/examples/counter/webpack-assets.json
@@ -1,0 +1,1 @@
+{"main":{"js":"/assets/client_bundle.b47c924f10336acd0dd1.js"}}

--- a/package.json
+++ b/package.json
@@ -47,14 +47,18 @@
     "isomorphic-style-loader": "^1.0.0"
   },
   "dependencies": {
+    "assets-webpack-plugin": "^3.4.0",
     "async-props": "^0.3.2",
     "autoprefixer": "^6.3.3",
     "babel-core": "^6.14.0",
     "babel-eslint": "^7.0.0",
     "babel-loader": "^6.2.5",
     "babel-plugin-react-require": "^2.1.0",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-es2015-node6": "^0.3.0",
+    "babel-preset-es2016": "^6.11.3",
+    "babel-preset-es2017": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-1": "^6.13.0",
     "babel-register": "^6.14.0",
@@ -83,7 +87,7 @@
     "strip-json-comments": "^2.0.1",
     "strip-json-comments-loader": "0.0.2",
     "url-loader": "^0.5.7",
-    "webpack": "2.1.0-beta.22",
+    "webpack": "2.1.0-beta.25",
     "webpack-dev-middleware": "^1.5.1",
     "webpack-hot-middleware": "^2.11.0"
   },

--- a/src/server/components/AppContainer.jsx
+++ b/src/server/components/AppContainer.jsx
@@ -8,20 +8,13 @@ const propTypes = {
     script: PropTypes.object.isRequired,
     initialState: PropTypes.object,
     children: PropTypes.string.isRequired,
+    entryPaths: PropTypes.shape({
+        [config.build.client.filename]: PropTypes.string.isRequired,
+    }).isRequired,
 };
 
-const buildSourceUrl = () =>
-    `${config.server.externalUrl
-        + config.server.basePath
-        + config.build.client.publicPath}/${
-        /* global __VITAMIN__CLIENT_BUNDLE_VERSION__ */
-        config.build.client.filename.replace(/\[hash\]/,
-            module.hot ? 'hot' : __VITAMIN__CLIENT_BUNDLE_VERSION__
-        )}`
-;
-
 /* eslint-disable react/no-danger */
-function AppContainer({ script, initialState, children }) {
+function AppContainer({ script, initialState, children, entryPaths }) {
     return (<div>
         <div
             id={config.rootElementId}
@@ -30,16 +23,18 @@ function AppContainer({ script, initialState, children }) {
         {initialState ?
             <script
                 dangerouslySetInnerHTML={{
-                    __html: `window.__INITIAL_STATE__ = "${
-                        jsStringEscape(stateStringifier(initialState))
-                    }"`,
+                    __html: `
+                        window.__INITIAL_STATE__ = "${
+                            jsStringEscape(stateStringifier(initialState))
+                        }"
+                        window.__ENTRY_PATHS__ = ${JSON.stringify(entryPaths)}`,
                 }}
             /> : null}
         {script.toComponent()}
         {initialState ?
             <script
                 async
-                src={buildSourceUrl()}
+                src={entryPaths[config.build.client.filename]}
             /> : null}
     </div>);
 }

--- a/src/server/components/DivLayout.jsx
+++ b/src/server/components/DivLayout.jsx
@@ -6,16 +6,17 @@ const propTypes = {
     initialState: PropTypes.object,
     head: PropTypes.object.isRequired,
     style: PropTypes.string.isRequired,
+    entryPaths: PropTypes.objectOf(PropTypes.string).isRequired,
 };
 
-const DivLayout = ({ appHtmlString, initialState, head, style }) => (
+const DivLayout = ({ appHtmlString, initialState, head, style, entryPaths }) =>
     <div>
         <style>{style}</style>
-        <AppContainer script={head.script} initialState={initialState}>
+        <AppContainer script={head.script} initialState={initialState} entryPaths={entryPaths} >
             {appHtmlString}
         </AppContainer>
     </div>
-);
+;
 
 DivLayout.propTypes = propTypes;
 export default DivLayout;

--- a/src/server/components/HtmlLayout.jsx
+++ b/src/server/components/HtmlLayout.jsx
@@ -6,9 +6,10 @@ const propTypes = {
     initialState: PropTypes.object,
     head: PropTypes.object.isRequired,
     style: PropTypes.string.isRequired,
+    entryPaths: PropTypes.objectOf(PropTypes.string),
 };
 
-const HtmlLayout = ({ appHtmlString, initialState, head, style }) => (
+const HtmlLayout = ({ appHtmlString, initialState, head, style, entryPaths = {} }) => (
     <html lang={head.htmlAttributes.lang} {...head.htmlAttributes}>
         <head>
             {head.title.toComponent()}
@@ -18,7 +19,7 @@ const HtmlLayout = ({ appHtmlString, initialState, head, style }) => (
             <style>{style}</style>
         </head>
         <body>
-            <AppContainer script={head.script} initialState={initialState}>
+            <AppContainer script={head.script} initialState={initialState} entryPaths={entryPaths}>
                 {appHtmlString}
             </AppContainer>
         </body>

--- a/src/server/getClientEntryPaths.js
+++ b/src/server/getClientEntryPaths.js
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import { appResolve } from '../../config/utils';
+import config from '../../config';
+
+export default () => (new Promise((resolve, reject) =>
+    fs.readFile(appResolve(config.build.path, 'webpack-assets.json'), 'utf8', (err, data) => (
+        err ? reject(err) : resolve(data)
+    )))
+    .then(webpackAssets =>
+        /* Return an object with key being the entry name, and the value, the absolute url */
+        Object.entries(JSON.parse(webpackAssets)).reduce((newEntries, [entryName, value]) => ({
+            [entryName]: Object.values(value)[0],
+            ...newEntries,
+        }), {}),
+        (err) => {
+            // eslint-disable-next-line no-console
+            console.error('Cannot open webpack-assets.json in the build folder. This file is' +
+            'needed for serving client bundle(s).');
+            throw err;
+        }
+    )
+);

--- a/src/server/middlewares/renderer.js
+++ b/src/server/middlewares/renderer.js
@@ -1,25 +1,6 @@
-import { loadPropsOnServer } from 'async-props';
 import render from '../render';
 
 export default () => function* rendererMiddleware() {
-    const renderProps = this.state.renderProps;
-    const store = this.state.store;
-    // Wrap async logic into a thenable to keep holding response until data is loaded, or not.
-    yield new Promise((resolve, reject) => {
-        loadPropsOnServer(
-            renderProps,
-            { dispatch: store.dispatch },
-            (error, asyncProps) => {
-                if (error) {
-                    return reject(error);
-                }
-                try {
-                    this.body = render(store, renderProps, asyncProps);
-                } catch (e) {
-                    return reject(e);
-                }
-                return resolve();
-            }
-        );
-    });
+    const { renderProps, store } = this.state;
+    this.body = yield render(renderProps, store);
 };

--- a/src/server/middlewares/staticAssetsServer.js
+++ b/src/server/middlewares/staticAssetsServer.js
@@ -4,30 +4,34 @@ import compose from 'koa-compose';
 import send from 'koa-send';
 import path from 'path';
 import config from '../../../config';
+import getClientEntryPaths from '../getClientEntryPaths';
 
-const clientEntries = [
-    ...Object.keys(config.build.client.secondaryEntries),
-    config.build.client.filename,
-]
-    /* global __VITAMIN__CLIENT_BUNDLE_VERSION__ */
-    .map(s => s.replace(
-        /\[hash\]/,
-        __VITAMIN__CLIENT_BUNDLE_VERSION__
-    ))
-    .map(s => `/${s}`);
 
-function serveClientEntries(entries) {
-    return function* serveClientEntriesMiddleware(next) {
-        if (entries.indexOf(this.url) !== -1) {
-            yield send(this, this.url.slice(1), { root: config.build.path });
-        } else {
-            yield next;
-        }
-    };
+function* serveClientEntries(next) {
+    const entryPaths = yield getClientEntryPaths();
+    const relativeEntryPaths = Object.values(entryPaths)
+        .filter(s => !s.startsWith('http') && !s.startsWith('//'))
+        .map(s =>
+            s.slice(config.server.basePath.length + config.build.client.publicPath.length)
+        );
+    if (relativeEntryPaths.indexOf(this.url) !== -1) {
+        yield send(this, this.url.slice(1), { root: config.build.path });
+    } else {
+        yield next;
+    }
+}
+
+function* serveStaticAssetsRegistry(next) {
+    if (this.url !== '/entry-paths.json') {
+        yield next;
+    } else {
+        this.body = yield getClientEntryPaths();
+    }
 }
 
 const serveStaticAssets = compose([
-    serveClientEntries(clientEntries),
+    serveClientEntries,
+    serveStaticAssetsRegistry,
     mount('/files', serve(path.join(config.build.path, 'files'))),
 ]);
 

--- a/src/server/render.jsx
+++ b/src/server/render.jsx
@@ -1,27 +1,44 @@
+import AsyncProps, { loadPropsOnServer } from 'async-props';
+import { renderToStaticMarkup, renderToString } from 'react-dom/server';
+import Helmet from 'react-helmet';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import Layout from '__app_modules__server_layout__';
-import { renderToStaticMarkup, renderToString } from 'react-dom/server';
-import AsyncProps from 'async-props';
-import Helmet from 'react-helmet';
+
 import App from '../shared/components/App';
+import getClientEntryPaths from './getClientEntryPaths';
 
-export function renderLayout(props) {
-    return `${Layout.doctype ? `${Layout.doctype}\n` : ''}${
-        renderToStaticMarkup(<Layout {...props} />)}`;
-}
+export const renderLayout = props =>
+    `${Layout.doctype ? `${Layout.doctype}\n` : ''}${
+    renderToStaticMarkup(<Layout {...props} />)}`
+;
 
-export default function render(store, renderProps, asyncProps) {
+// Return a promise that resolves to the html string
+export default (renderProps, store) => {
     const css = [];
     const insertCss = styles => css.push(styles._getCss());
-
-    const app = (<App store={store} insertCss={insertCss}>
-        <AsyncProps {...renderProps} {...asyncProps} />
-    </App>);
-
-    return renderLayout({
-        appHtmlString: renderToString(app),
-        style: css.join(''),
-        head: Helmet.rewind(),
-        initialState: store.getState(),
-    });
+    return getClientEntryPaths().then(entryPaths =>
+        new Promise((resolve, reject) => loadPropsOnServer(
+            renderProps,
+            { dispatch: store.dispatch },
+            (error, asyncProps) => {
+                if (error) {
+                    return reject(error);
+                }
+                try {
+                    return resolve(renderLayout({
+                        appHtmlString: renderToString(<App store={store} insertCss={insertCss}>
+                            <AsyncProps {...renderProps} {...asyncProps} />
+                        </App>),
+                        style: css.join(''),
+                        head: Helmet.rewind(),
+                        initialState: store.getState(),
+                        entryPaths,
+                    }));
+                } catch (err) {
+                    return reject(err);
+                }
+            }
+        ))
+    );
 }
+;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -4,36 +4,21 @@ import express from 'express';
 import config from '../../config';
 import app from './app';
 
-
 function hotReloadServer() {
     const server = express();
     const webpack = require('webpack');
-    let clientBuildConfig = require('../../config/build/webpack.config.client')({
+    const clientBuildConfig = require('../../config/build/webpack.config.client')({
         hot: true,
         dev: true,
     });
 
-    const hmrPath = `${config.server.basePath + config.build.client.publicPath}/__webpack_hmr`;
-    clientBuildConfig = clientBuildConfig
-        .map(webpackConfig => ({
-            ...webpackConfig,
-            entry: [
-                webpackConfig.entry,
-                `webpack-hot-middleware/client?path=${config.server.externalUrl + hmrPath}`,
-            ],
-        }))
-        .map(webpackConfig => ({
-            ...webpackConfig,
-            output: {
-                ...webpackConfig.output,
-                filename: webpackConfig.output.filename.replace(/\[hash\]/, 'hot'),
-            },
-        }));
     const compiler = webpack(clientBuildConfig);
     server.use(require('webpack-dev-middleware')(compiler, {
         noInfo: true,
         publicPath: clientBuildConfig[0].output.publicPath,
     }));
+
+    const hmrPath = `${config.server.basePath + config.build.client.publicPath}/__webpack_hmr`;
     server.use(require('webpack-hot-middleware')(compiler, {
         path: hmrPath,
         quiet: true,


### PR DESCRIPTION
You can now add a [hash] placeholder inside your filename in the config. It
will be replace with the file compilation hash.

You can access to the filename / hash mapping in the browser though the global
object `__ENTRY_PATHS__`

Known caveats : If you are using a serviceWorker to cache all the resources,
it is not possible to have access to the window object. So you cannot have
the proper filenames. We are investingating on a solution. We did not find
the ideal one yet. You'll be updated when it is the case.