### PR TITLE
babel transform-runtime disable polyfills

### DIFF
--- a/config/build/babelrc.js
+++ b/config/build/babelrc.js
@@ -21,7 +21,7 @@ export default env => ({
         pluginReactRequire,
         // Add Object.entries, Object.values and other ES2017 functionalities
         ...(env === 'server' ?
-            [pluginTransformRuntime] :
+            [[pluginTransformRuntime, { polyfill: false }]] :
             // in the client, we prefer solution like https://polyfill.io/v2/docs/, to keep the
             // bundle size the smallest possible.
             []


### PR DESCRIPTION
requires node 7 or node 6 with harmony flag