### PR TITLE
babel-plugin-discard-module-references@1.1.2

### DIFF
--- a/config/build/babelrc.js
+++ b/config/build/babelrc.js
@@ -47,7 +47,7 @@ export default env => ({
         pluginNodeEnvInline,
         pluginMinifyDeadCodeElimination,
         pluginMinifyGuardedExpressions,
-        [pluginDiscardModuleReferences, { targets: [] }],
+        pluginDiscardModuleReferences,
     ],
     sourceRoot: vitaminResolve(),
 });

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "babel-core": "^6.14.0",
     "babel-eslint": "^7.0.0",
     "babel-loader": "^6.2.5",
-    "babel-plugin-discard-module-references": "^1.1.0",
+    "babel-plugin-discard-module-references": "^1.1.2",
     "babel-plugin-minify-dead-code-elimination": "0.0.4",
     "babel-plugin-minify-guarded-expressions": "0.0.3",
     "babel-plugin-minify-replace": "0.0.1",


### PR DESCRIPTION
https://github.com/ArnaudRinquin/babel-plugin-discard-module-references/pull/2

targets option is now optional !