### PR TITLE
Revert "Update postcss-loader to version 1.0.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "koa-static": "^2.0.0",
     "lodash.mergewith": "^4.0.4",
     "node-fetch": "^1.6.3",
-    "postcss-loader": "^1.0.0",
+    "postcss-loader": "^0.13.0",
     "progress": "^1.1.8",
     "react-dom": "^15.3.0",
     "redbox-react": "^1.2.9",


### PR DESCRIPTION
Reverts Evaneos/vitaminjs#134

We have a lot of errors : `Error: Cannot read property 'config' of null`
