### PR TITLE
add ttf and eot file types in url-loader webpack loader test

### DIFF
--- a/config/build/webpack.config.common.js
+++ b/config/build/webpack.config.common.js
@@ -51,7 +51,7 @@ export function config(options) {
                     'postcss-loader',
                 ],
             }, {
-                test: /\.(png|jpg|jpeg|gif|svg|woff|woff2)$/,
+                test: /\.(png|jpg|jpeg|gif|svg|woff|woff2|eot|ttf)$/,
                 loader: 'url-loader?limit=10000&name=files/[hash].[ext]',
             }, {
                 test: /\.json$/,


### PR DESCRIPTION
allow ttf and eot files to be loaded in vitamin project