### PR TITLE
render Helmet scripts into document header

### DIFF
--- a/src/server/components/HtmlLayout.jsx
+++ b/src/server/components/HtmlLayout.jsx
@@ -26,10 +26,10 @@ const HTMLLayout = ({ head, style, children }) => (
             {head.link.toComponent()}
             {head.base.toComponent()}
             <style>{style}</style>
+            {head.script.toComponent()}
         </head>
         <body>
             {children}
-            {head.script.toComponent()}
         </body>
     </html>
 );


### PR DESCRIPTION
script async attributes should be used to make a script loading
non-blocking instead of including scripts at body’s tail.