### PR TITLE
<fix> Script tag position containing server initialState

### DIFF
--- a/src/server/components/AppContainer.jsx
+++ b/src/server/components/AppContainer.jsx
@@ -14,13 +14,13 @@ const propTypes = {
 function AppContainer({ initialState, children, mainEntry }) {
     return (<div>
         <script async src={`${config.publicPath}/${mainEntry}`} />
-        <div
-            dangerouslySetInnerHTML={{ __html: children }}
-        />
         <script
             dangerouslySetInnerHTML={{ __html: `
                 window.__INITIAL_STATE__ = "${jsStringEscape(stateStringifier(initialState))}"`,
             }}
+        />
+        <div
+            dangerouslySetInnerHTML={{ __html: children }}
         />
     </div>);
 }


### PR DESCRIPTION
This commit fixes a bug where the initialState was not always correctly parsed by the server and then creating an error when the client tries to access it.