### PR TITLE
feat: add support for YAML files

### DIFF
--- a/config/build/webpack.config.common.js
+++ b/config/build/webpack.config.common.js
@@ -66,6 +66,9 @@ export function config(options) {
             }, {
                 test: /\.json$/,
                 loader: 'json-loader',
+            }, {
+                test: /\.ya?ml$/,
+                loader: 'yaml-loader',
             }],
         },
 

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "url-loader": "^0.5.7",
     "webpack": "^2.2.1",
     "webpack-dev-middleware": "^1.10.0",
-    "webpack-hot-middleware": "^2.16.1"
+    "webpack-hot-middleware": "^2.16.1",
+    "yaml-loader": "^0.4.0"
   },
   "engines": {
     "node": ">=6.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2633,7 +2633,7 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@~3.7.0:
+js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.5.2, js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
@@ -4655,6 +4655,12 @@ xtend@^4.0.0:
 y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+
+yaml-loader@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/yaml-loader/-/yaml-loader-0.4.0.tgz#4aae447d13c1aa73a989d8a2a5309b0b1a3ca353"
+  dependencies:
+    js-yaml "^3.5.2"
 
 yargs-parser@^4.2.0:
   version "4.2.1"


### PR DESCRIPTION
WHY
---

YAML is no more than a "cleaner" way to write JSON objects (and I like it 😏)

CHANGELOG
---
- add `yaml-loader` in webpack common config