### PR TITLE
BREAKING: change vitaminjs default export to namespaced one

### DIFF
--- a/examples/counter/Counter/index.jsx
+++ b/examples/counter/Counter/index.jsx
@@ -1,5 +1,7 @@
 import { PropTypes } from 'react';
-import { connect, compose, withStyles } from 'vitaminjs';
+import { connect } from 'vitaminjs/react-redux';
+import { compose } from 'vitaminjs/redux';
+import { withStyles } from 'vitaminjs';
 import s from './style.css';
 
 const Counter = ({ value, onIncrement, onDecrement }) =>

--- a/examples/counter/routes.jsx
+++ b/examples/counter/routes.jsx
@@ -1,4 +1,4 @@
-import { Route } from 'react-router';
+import { Route } from 'vitaminjs/react-router';
 import Counter from './Counter/index.jsx';
 
 export default (

--- a/react-helmet.js
+++ b/react-helmet.js
@@ -1,0 +1,1 @@
+export * from 'react-helmet';

--- a/react-helmet.js
+++ b/react-helmet.js
@@ -1,1 +1,1 @@
-export * from 'react-helmet';
+export default from 'react-helmet';

--- a/react-redux.js
+++ b/react-redux.js
@@ -1,0 +1,1 @@
+export { Provider, connectAdvanced, connect } from 'react-redux';

--- a/react-resolver.js
+++ b/react-resolver.js
@@ -1,0 +1,1 @@
+export { client, context, resolve } from 'react-resolver';

--- a/react-router-redux.js
+++ b/react-router-redux.js
@@ -1,0 +1,5 @@
+export {
+    LOCATION_CHANGE, routerReducer, CALL_HISTORY_METHOD,
+    push, replace, go, goBack, goForward,
+    routerActions, routerMiddleware,
+} from 'react-router-redux';

--- a/react-router.js
+++ b/react-router.js
@@ -1,0 +1,2 @@
+export { Link, IndexLink, withRouter, Route, Redirect, IndexRoute, IndexRedirect, PropTypes,
+    } from 'react-router';

--- a/redux.js
+++ b/redux.js
@@ -1,0 +1,1 @@
+export { combineReducers, bindActionCreators, applyMiddleware, compose } from 'redux';

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -1,13 +1,1 @@
 export withStyles from 'isomorphic-style-loader/lib/withStyles';
-export Helmet from 'react-helmet';
-export { client, context, resolve } from 'react-resolver';
-export { combineReducers, bindActionCreators, applyMiddleware, compose } from 'redux';
-export { Provider, connectAdvanced, connect } from 'react-redux';
-export * from 'react-router';
-
-export {
-    LOCATION_CHANGE, routerReducer, CALL_HISTORY_METHOD,
-    push, replace, go, goBack, goForward,
-    routerActions, routerMiddleware,
-} from 'react-router-redux';
-


### PR DESCRIPTION
### Motivation
While the previous way of exporting has some advantage (import were less verbose
and more concise), it has several drawbacks.

- It could result in nameclash
- It make confuse the difference between the vitamin exports and the library ones
- It hide the names of the libraries used
- Last, but not least, it constrain the user to keep using vitaminJS, by preventing
it to switch easily its project. Indeed, while it's easy to remove the 'vitaminjs'
in the line `import { connect } from 'vitaminjs/react-redux'`, it's quite long to
separe all the import when they are all grouped together
(eg: `import { connect, Route, withStyles } from 'vitaminjs'`)

### Implementation details
We could have chosen to configure webpack to resolve `vitaminjs/<something>` to
a subfolder (eg `exports`), however, this would not have been understood by IDEs
and linter. As a result, the imports could have been wrongly signaled as
unresolved by those tools.

This is why we choose a more classical approach, even if it bloat a little bit
the root folder of the git repository.