### PR TITLE
fix: use NoEmitOnErrorsPlugin instead of deprecated NoErrorsPlugin

### DIFF
--- a/config/build/webpack.config.client.js
+++ b/config/build/webpack.config.client.js
@@ -28,7 +28,7 @@ export default function clientConfig(options) {
                 'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
             }),
 
-            options.hot && new webpack.NoErrorsPlugin(),
+            options.hot && new webpack.NoEmitOnErrorsPlugin(),
             options.hot && new webpack.optimize.OccurrenceOrderPlugin(),
 
             !options.dev && new webpack.optimize.UglifyJsPlugin({ minimize: true }),


### PR DESCRIPTION
`NoErrorsPlugin` is now deprecated as describe in issue https://github.com/webpack/webpack/issues/3179

We now use `NoEmitOnErrorsPlugin` instead