### PR TITLE
feat: remove export default in app reducers file

### DIFF
--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -36,7 +36,7 @@ function bootstrapClient() {
 
     const store = createStore(
         history,
-        reducers.default || reducers,
+        reducers,
         middlewares,
         initialState,
     );
@@ -60,7 +60,7 @@ function bootstrapClient() {
             // eslint-disable-next-line global-require, import/no-extraneous-dependencies
             const newReducers = require('__app_modules__redux_reducers__');
 
-            store.replaceReducer(createRootReducer(newReducers.default || newReducers));
+            store.replaceReducer(createRootReducer(newReducers));
         });
         module.hot.accept('__app_modules__routes__', () => {
             // eslint-disable-next-line global-require, import/no-extraneous-dependencies

--- a/src/server/middlewares/store.js
+++ b/src/server/middlewares/store.js
@@ -18,6 +18,6 @@ export default () => (ctx, next) => {
         entries: [ctx.req.url],
     });
     ctx.state.history = history;
-    ctx.state.store = createStore(history, reducers.default || reducers, middlewares);
+    ctx.state.store = createStore(history, reducers, middlewares);
     return next();
 };


### PR DESCRIPTION

BREAKING: please use `export const` or `export from` instead of `export default` in your index reducers