### PR TITLE
Add documentation for deploying to heroku

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,2 +1,13 @@
+### Can I deploy vitamin to heroku?
+
+Absolutely! From your application directory, you can set the buildpack like this:
+```
+$ heroku buildpacks set:https://github.com/victormours/heroku-buildpack-vitaminjs
+```
+
+And then just `git push heroku master`
+
+And you're done!
+
 ### How to do change the HTML layout of a page ?
 ### How to display something while AsyncProps loads data


### PR DESCRIPTION
This is the updated version of https://github.com/Evaneos/vitaminjs/pull/252 (TIL you can't reopen a pull request if you force push).

The `HOST` is now set by the buildpack, so there is no need to change the `.vitaminrc`.

That's pretty much as easy as it gets. :-)