### PR TITLE
fix: add postcss plugin to handle values in css modules

### DIFF
--- a/config/build/webpack.config.common.js
+++ b/config/build/webpack.config.common.js
@@ -2,6 +2,7 @@ import { HotModuleReplacementPlugin, LoaderOptionsPlugin, NamedModulesPlugin } f
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import postcssOmitImportTilde from 'postcss-omit-import-tilde';
 import postcssImport from 'postcss-import';
+import postcssModulesValues from 'postcss-modules-values';
 import postcssUrl from 'postcss-url';
 import postcssCssNext from 'postcss-cssnext';
 import postcssBrowserReporter from 'postcss-browser-reporter';
@@ -95,6 +96,7 @@ export function config(options) {
                     postcss: [
                         postcssOmitImportTilde(),
                         postcssImport(),
+                        postcssModulesValues,
                         postcssUrl(),
                         postcssCssNext(),
                         !options.dev && postcssCssNano({ autoprefixer: false }),

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "postcss-cssnext": "^2.9.0",
     "postcss-import": "^9.1.0",
     "postcss-loader": "^1.3.3",
+    "postcss-modules-values": "^1.2.2",
     "postcss-omit-import-tilde": "^1.0.1",
     "postcss-reporter": "^3.0.0",
     "postcss-url": "^5.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3955,7 +3955,7 @@ postcss-modules-scope@^1.0.0:
     css-selector-tokenizer "^0.6.0"
     postcss "^5.0.4"
 
-postcss-modules-values@^1.1.0:
+postcss-modules-values@^1.1.0, postcss-modules-values@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-1.2.2.tgz#f0e7d476fe1ed88c5e4c7f97533a3e772ad94ca1"
   dependencies:


### PR DESCRIPTION
CSS modules provides values in css to pass arbitrary values in your css. It works with the help of a
postcss plugin. It was missing in vitamin. This commit fixes it !