### PR TITLE
tests: yarn frozen-lockfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run:
           name: Dependencies
-          command: yarn install --no-progress && yarn link
+          command: yarn install --no-progress --frozen-lockfile && yarn link
       - run:
           name: Lint
           command: yarn lint


### PR DESCRIPTION
Checks that the yarn is updated with the dependencies in package.json

⚠️ All greenkeeper PR will fail
related: https://github.com/greenkeeperio/greenkeeper/issues/314

We will need to manually go to the greenkeeper branch, play yarn to update the lock file and then push to check if the test pass.