### PR TITLE
feat: defer app execution to allow use of polyfill

### DIFF
--- a/src/server/components/App.jsx
+++ b/src/server/components/App.jsx
@@ -23,7 +23,7 @@ const App = ({ store, insertCss, renderProps, mainEntry }) => (
         <Helmet
             script={[
                 { innerHTML: `window.__INITIAL_STATE__ = "${jsStringEscape(stateStringifier(store.getState()))}"` },
-                { src: `${config.publicPath}/${mainEntry}`, async: true },
+                { src: `${config.publicPath}/${mainEntry}`, defer: true },
             ]}
         />
         <RouterContext {...renderProps} />


### PR DESCRIPTION
When dealing with MSIE, you (may) need polyfill for Promise, Object.assign or other basic still great features. Problem is, polyfill.io (for instance) needs to be executed before our `client_bundle`.