### PR TITLE
feat(webpack): enable user to provide aliases though new config key

### DIFF
--- a/API.md
+++ b/API.md
@@ -30,6 +30,8 @@ file at the root of your project.
   - [serviceWorker](#serviceWorker)
   - [targetBrowsers](#targetBrowsers)
 - [extends](#extends)
+- [webpack](#webpack)
+  - [alias](#alias)
 - [rootElementId](#rootElementId)
 
 ## <a id='routes'></a>[`routes`](#routes)
@@ -211,6 +213,13 @@ If you want to run your application without headers, you can define here the ele
 **`Path`**
 
 Make your .vitaminrc extends another vitamin config. It is useful in case you want to have a base configuration for multiple environments.
+
+## <a id='webpack'></a>[`webpack`](#webpack)
+Endpoint to customize some specific webpack config.
+### <a id='alias'></a>[`alias`](#alias)
+**`Object`** 
+Add your own aliases for custome resolution. 
+
 
 # Globals
 ## <a id='isclient-isserver'></a>[`IS_CLIENT` / `IS_SERVER`](#isclient-isserver)

--- a/config/build/webpack.config.common.js
+++ b/config/build/webpack.config.common.js
@@ -1,4 +1,8 @@
-import { HotModuleReplacementPlugin, LoaderOptionsPlugin, NamedModulesPlugin } from 'webpack';
+import {
+    HotModuleReplacementPlugin,
+    LoaderOptionsPlugin,
+    NamedModulesPlugin,
+} from 'webpack';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import WatchMissingNodeModulesPlugin from 'react-dev-utils/WatchMissingNodeModulesPlugin';
 import postcssOmitImportTilde from 'postcss-omit-import-tilde';
@@ -20,10 +24,11 @@ const MODULES_DIRECTORIES = [APP_MODULES, VITAMIN_MODULES_DIRECTORY];
 export const createBabelLoader = (env, options) => ({
     test: /\.js(x?)$/,
     loader: 'babel-loader',
-    include: path => !path.includes('node_modules') ||
-        (path.startsWith(VITAMIN_DIRECTORY)
-         && !path.startsWith(VITAMIN_MODULES_DIRECTORY)
-         && !path.startsWith(VITAMIN_MODULES_EXAMPLES_DIRECTORY)),
+    include: path =>
+        !path.includes('node_modules') ||
+        (path.startsWith(VITAMIN_DIRECTORY) &&
+            !path.startsWith(VITAMIN_MODULES_DIRECTORY) &&
+            !path.startsWith(VITAMIN_MODULES_EXAMPLES_DIRECTORY)),
     query: babelrc(env, options),
 });
 
@@ -49,11 +54,14 @@ export function config(options) {
                     removeAll: !options.dev,
                 },
                 importLoaders: 1,
-                ...(modules ? {
-                    localIdentName: options.dev ?
-                        '[name]__[local]___[hash:base64:5]' : '[hash:base64]',
-                    modules: true,
-                } : {}),
+                ...(modules
+                    ? {
+                          localIdentName: options.dev
+                              ? '[name]__[local]___[hash:base64:5]'
+                              : '[hash:base64]',
+                          modules: true,
+                      }
+                    : {}),
             },
         },
         'postcss-loader',
@@ -75,28 +83,34 @@ export function config(options) {
             wrappedContextRegExp: /$^/,
             wrappedContextCritical: true,
 
-            rules: [{
-                // only files with .global will go through this loader
-                test: /\.global\.css$/,
-                loaders: CSSLoaders({ modules: false }),
-            }, {
-                // anything with .global will not go through css modules loader
-                test: /^((?!\.global).)*\.css$/,
-                loaders: CSSLoaders({ modules: true }),
-            }, {
-                test: /\.(png|jpg|jpeg|gif|svg|ico|woff|woff2|eot|ttf)$/,
-                loader: 'url-loader',
-                options: {
-                    limit: 10000,
-                    name: join(options.filesPath, '[hash].[ext]'),
+            rules: [
+                {
+                    // only files with .global will go through this loader
+                    test: /\.global\.css$/,
+                    loaders: CSSLoaders({ modules: false }),
                 },
-            }, {
-                test: /\.json$/,
-                loader: 'json-loader',
-            }, {
-                test: /\.ya?ml$/,
-                loader: 'yaml-loader',
-            }],
+                {
+                    // anything with .global will not go through css modules loader
+                    test: /^((?!\.global).)*\.css$/,
+                    loaders: CSSLoaders({ modules: true }),
+                },
+                {
+                    test: /\.(png|jpg|jpeg|gif|svg|ico|woff|woff2|eot|ttf)$/,
+                    loader: 'url-loader',
+                    options: {
+                        limit: 10000,
+                        name: join(options.filesPath, '[hash].[ext]'),
+                    },
+                },
+                {
+                    test: /\.json$/,
+                    loader: 'json-loader',
+                },
+                {
+                    test: /\.ya?ml$/,
+                    loader: 'yaml-loader',
+                },
+            ],
         },
 
         resolveLoader: {
@@ -104,7 +118,10 @@ export function config(options) {
         },
         cache: options.hot,
         resolve: {
-            alias: options.moduleMap,
+            alias: {
+                ...options.webpack.alias,
+                ...options.moduleMap,
+            },
             modules: MODULES_DIRECTORIES,
             extensions: ['.js', '.jsx', '.json', '.css'],
             mainFields: ['browser', 'module', 'main', 'style'],
@@ -117,7 +134,9 @@ export function config(options) {
                         postcssOmitImportTilde(),
                         postcssImport(),
                         postcssUrl(),
-                        postcssCssNext({ browsers: options.client.targetBrowsers }),
+                        postcssCssNext({
+                            browsers: options.client.targetBrowsers,
+                        }),
                         options.dev && postcssBrowserReporter(),
                         postcssReporter(),
                     ].filter(Boolean),

--- a/config/build/webpack.config.common.js
+++ b/config/build/webpack.config.common.js
@@ -1,8 +1,4 @@
-import {
-    HotModuleReplacementPlugin,
-    LoaderOptionsPlugin,
-    NamedModulesPlugin,
-} from 'webpack';
+import { HotModuleReplacementPlugin, LoaderOptionsPlugin, NamedModulesPlugin } from 'webpack';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import WatchMissingNodeModulesPlugin from 'react-dev-utils/WatchMissingNodeModulesPlugin';
 import postcssOmitImportTilde from 'postcss-omit-import-tilde';
@@ -24,11 +20,10 @@ const MODULES_DIRECTORIES = [APP_MODULES, VITAMIN_MODULES_DIRECTORY];
 export const createBabelLoader = (env, options) => ({
     test: /\.js(x?)$/,
     loader: 'babel-loader',
-    include: path =>
-        !path.includes('node_modules') ||
-        (path.startsWith(VITAMIN_DIRECTORY) &&
-            !path.startsWith(VITAMIN_MODULES_DIRECTORY) &&
-            !path.startsWith(VITAMIN_MODULES_EXAMPLES_DIRECTORY)),
+    include: path => !path.includes('node_modules') ||
+        (path.startsWith(VITAMIN_DIRECTORY)
+         && !path.startsWith(VITAMIN_MODULES_DIRECTORY)
+         && !path.startsWith(VITAMIN_MODULES_EXAMPLES_DIRECTORY)),
     query: babelrc(env, options),
 });
 
@@ -54,14 +49,11 @@ export function config(options) {
                     removeAll: !options.dev,
                 },
                 importLoaders: 1,
-                ...(modules
-                    ? {
-                          localIdentName: options.dev
-                              ? '[name]__[local]___[hash:base64:5]'
-                              : '[hash:base64]',
-                          modules: true,
-                      }
-                    : {}),
+                ...(modules ? {
+                    localIdentName: options.dev ?
+                        '[name]__[local]___[hash:base64:5]' : '[hash:base64]',
+                    modules: true,
+                } : {}),
             },
         },
         'postcss-loader',
@@ -83,34 +75,28 @@ export function config(options) {
             wrappedContextRegExp: /$^/,
             wrappedContextCritical: true,
 
-            rules: [
-                {
-                    // only files with .global will go through this loader
-                    test: /\.global\.css$/,
-                    loaders: CSSLoaders({ modules: false }),
+            rules: [{
+                // only files with .global will go through this loader
+                test: /\.global\.css$/,
+                loaders: CSSLoaders({ modules: false }),
+            }, {
+                // anything with .global will not go through css modules loader
+                test: /^((?!\.global).)*\.css$/,
+                loaders: CSSLoaders({ modules: true }),
+            }, {
+                test: /\.(png|jpg|jpeg|gif|svg|ico|woff|woff2|eot|ttf)$/,
+                loader: 'url-loader',
+                options: {
+                    limit: 10000,
+                    name: join(options.filesPath, '[hash].[ext]'),
                 },
-                {
-                    // anything with .global will not go through css modules loader
-                    test: /^((?!\.global).)*\.css$/,
-                    loaders: CSSLoaders({ modules: true }),
-                },
-                {
-                    test: /\.(png|jpg|jpeg|gif|svg|ico|woff|woff2|eot|ttf)$/,
-                    loader: 'url-loader',
-                    options: {
-                        limit: 10000,
-                        name: join(options.filesPath, '[hash].[ext]'),
-                    },
-                },
-                {
-                    test: /\.json$/,
-                    loader: 'json-loader',
-                },
-                {
-                    test: /\.ya?ml$/,
-                    loader: 'yaml-loader',
-                },
-            ],
+            }, {
+                test: /\.json$/,
+                loader: 'json-loader',
+            }, {
+                test: /\.ya?ml$/,
+                loader: 'yaml-loader',
+            }],
         },
 
         resolveLoader: {
@@ -134,9 +120,7 @@ export function config(options) {
                         postcssOmitImportTilde(),
                         postcssImport(),
                         postcssUrl(),
-                        postcssCssNext({
-                            browsers: options.client.targetBrowsers,
-                        }),
+                        postcssCssNext({ browsers: options.client.targetBrowsers }),
                         options.dev && postcssBrowserReporter(),
                         postcssReporter(),
                     ].filter(Boolean),

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -35,6 +35,9 @@ export default {
             'not ie < 9', // react doesn't support ie < 9
         ],
     },
+    webpack: {
+        alias: {},
+    },
     filesPath: 'files',
     rootElementId: 'vitamin-app',
 };

--- a/config/index.js
+++ b/config/index.js
@@ -139,6 +139,13 @@ export default () => {
         updatePath(path, appResolve, config),
     );
 
+    // Resolve user webpack alias to absolute paths
+    Object.keys(config.webpack.alias)
+        .map(aliasKey => ['webpack', 'alias', aliasKey])
+        .forEach(path =>
+            updatePath(path, appResolve, config)
+        )
+
     // Prepend / to publicPath and basePath if necessary
     const prependSlash = path => (
         ((path.startsWith('/') || path.match(/^(http|\/|$)/)) ? '' : '/') + path

--- a/config/index.js
+++ b/config/index.js
@@ -143,8 +143,8 @@ export default () => {
     Object.keys(config.webpack.alias)
         .map(aliasKey => ['webpack', 'alias', aliasKey])
         .forEach(path =>
-            updatePath(path, appResolve, config)
-        )
+            updatePath(path, appResolve, config),
+        );
 
     // Prepend / to publicPath and basePath if necessary
     const prependSlash = path => (


### PR DESCRIPTION
Add a new config key: webpack alias in `.vitaminrc`

Justification: sometimes, you want to be able to specify custome aliases, for instance for libraries
where entry point need some very specific webpack config to be built. In that case you may want to
use the compiled js instead (for instance, that the case of mapbox-gl
https://github.com/mapbox/mapbox-gl-js/issues/1649)

❤️ 