### PR TITLE
feat(build): add plugin support to vitaminjs-build

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,30 +7,32 @@ file at the root of your project.
 
 - [routes](#routes)
 - [redux](#redux)
- - [reducers](#reducers)
- - [middlewares](#reduxMiddlewares)
- - [enhancers](#enhancers)
- - [stateSerializer](#stateSerializer)
+  - [reducers](#reducers)
+  - [middlewares](#reduxMiddlewares)
+  - [enhancers](#enhancers)
+  - [stateSerializer](#stateSerializer)
 - [server](#server)
- - [buildPath](#buildPath)
- - [filename](#serverFilename)
- - [host](#host)
- - [port](#port)
- - [middlewares](#serverMiddlewares)
- - [createInitAction](#createInitAction)
- - [layout](#layout)
- - [ErrorPage](#ErrorPage)
- - [onError](#onError)
+  - [buildPath](#buildPath)
+  - [filename](#serverFilename)
+  - [host](#host)
+  - [port](#port)
+  - [middlewares](#serverMiddlewares)
+  - [createInitAction](#createInitAction)
+  - [layout](#layout)
+  - [ErrorPage](#ErrorPage)
+  - [onError](#onError)
 - [basePath](#basepath)
 - [publicPath](#publicPath)
 - [servePublic](#servePublic)
 - [client](#client)
- - [filename](#clientFilename)
- - [buildPath](#clientBuildPath)
- - [serviceWorker](#serviceWorker)
- - [targetBrowsers](#targetBrowsers)
+  - [filename](#clientFilename)
+  - [buildPath](#clientBuildPath)
+  - [serviceWorker](#serviceWorker)
+  - [targetBrowsers](#targetBrowsers)
 - [extends](#extends)
 - [rootElementId](#rootElementId)
+- [plugins](#plugins)
+
 
 ## <a id='routes'></a>[`routes`](#routes)
 **`Path (`[`<Route>`](https://github.com/reactjs/react-router/blob/master/docs/API.md#route)` | `[`store`](http://redux.js.org/docs/api/Store.html#store)` => `[`<Route>`](https://github.com/reactjs/react-router/blob/master/docs/API.md#route)`)`**
@@ -212,6 +214,11 @@ If you want to run your application without headers, you can define here the ele
 **`Path`**
 
 Make your .vitaminrc extends another vitamin config. It is useful in case you want to have a base configuration for multiple environments.
+
+## <a id='plugins'></a>[`plugins`](#plugins)
+**`String`**
+
+You can add new behaviour to vitaminjs thanks to plugins. See the plugin section in the README
 
 # Globals
 ## <a id='isclient-isserver'></a>[`IS_CLIENT` / `IS_SERVER`](#isclient-isserver)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ npm run build
 
 It bundles your application and optimizes its performances. The bundle is also minified.
 
+## Plugins
+You can extend vitamin behaviour with plugins. Below is a list of useful plugins that we currently support
+
+- [vitaminjs-plugin-jest](https://github.com/Evaneos/vitaminjs/tree/master/packages/vitaminjs-plugin-jest): use Facebook's [Jest]('https://facebook.github.io/jest/') as a test runner in your application without configuration
+
 ## Frequently Asked Questions
 We have started to answer some frequently asked questions. You can find all of them here: [FAQ](https://github.com/Evaneos/vitaminjs/blob/master/FAQ.md)  
 If you have any questions you think are worth be displayed, please raise an issue in the project.  

--- a/packages/vitaminjs-build/bin/loadPlugins.js
+++ b/packages/vitaminjs-build/bin/loadPlugins.js
@@ -1,0 +1,24 @@
+import mergeWith from 'lodash.mergewith';
+import { concat } from '../config/utils';
+
+export default (program, config) => config.plugins.forEach(
+    plugin => {
+        const pluginCommand = require(`vitaminjs-plugin-${plugin}`).default;
+        if (pluginCommand.command) {
+            pluginCommand.command(program);
+        }
+    }
+);
+
+export const loadWebpackConfigPlugins = (webpackConfig, appConfig) => appConfig.plugins.reduce(
+    (config, plugin) => {
+        const webpackConfigPlugin = require(`vitaminjs-plugin-${plugin}`).default;
+
+        if (!webpackConfigPlugin.webpack) {
+            return config
+        }
+
+        return mergeWith({}, webpackConfig, webpackConfigPlugin.webpack, concat);
+    },
+    appConfig,
+);

--- a/packages/vitaminjs-build/bin/vitamin.js
+++ b/packages/vitaminjs-build/bin/vitamin.js
@@ -16,6 +16,7 @@ import webpackConfigServer from '../config/build/webpack.config.server';
 import webpackConfigClient from '../config/build/webpack.config.client';
 import webpackConfigTest from '../config/build/webpack.config.tests';
 import parseConfig, { rcPath as configRcPath } from '../config';
+import loadPlugins from './loadPlugins';
 import { version } from '../package.json';
 
 const DEV = process.env.NODE_ENV !== 'production';
@@ -311,5 +312,7 @@ program
             process.exit(1);
         });
     });
+
+loadPlugins(program, parseConfig());
 
 program.parse(process.argv);

--- a/packages/vitaminjs-build/config/build/webpack.config.common.js
+++ b/packages/vitaminjs-build/config/build/webpack.config.common.js
@@ -11,6 +11,7 @@ import { join } from 'path';
 import { isBuildModulePath, isExternalModulePath, isRuntimeModulePath, __isVitaminFacadeModulePath } from '../resolve';
 import { appResolve } from '../utils';
 import babelrc from './babelrc';
+import { loadWebpackConfigPlugins } from '../../bin/loadPlugins';
 
 const APP_MODULES = appResolve('node_modules');
 
@@ -63,7 +64,7 @@ export function config(options) {
         },
         'postcss-loader',
     ];
-    return {
+    const webpackCommonConfig = {
         devtool: options.dev && 'source-map',
         output: {
             pathinfo: options.dev,
@@ -150,4 +151,6 @@ export function config(options) {
             options.dev && new CaseSensitivePathsPlugin(),
         ].filter(Boolean),
     };
+
+    return loadWebpackConfigPlugins(webpackCommonConfig, options);
 }

--- a/packages/vitaminjs-build/config/defaults.js
+++ b/packages/vitaminjs-build/config/defaults.js
@@ -37,4 +37,5 @@ export default {
     },
     filesPath: 'files',
     rootElementId: 'vitamin-app',
+    plugins: [],
 };


### PR DESCRIPTION
This commit add support of plugins to VitaminJS.
It adds the key `plugins` in `.vitaminrc`

There are two types of plugins supported with this commit :

The first one dynamically adds command from a plugin to the
vitamin binary.

The second one adds config to webpack config. Plugin config will
always override vitamin's default config.