### PR TITLE
feat(config): add source-maps in production

### DIFF
--- a/packages/vitaminjs-build/bin/vitamin.js
+++ b/packages/vitaminjs-build/bin/vitamin.js
@@ -251,13 +251,16 @@ program
     .alias('b')
     .description('Build server and client bundles')
     .option('-h, --hot', 'Activate hot module reload')
-    .action(({ hot }) => build({ hot: checkHot(hot) })
-        .catch((err) => {
-            if (err !== BUILD_FAILED) {
-                console.log(err.stack || err);
-            }
-            process.exit(1);
-        }),
+    .option('--with-source-maps', 'Generate source maps')
+    .action(({ hot, withSourceMaps }) => {
+        build({ hot: checkHot(hot), withSourceMaps })
+            .catch((err) => {
+                if (err !== BUILD_FAILED) {
+                    console.log(err.stack || err);
+                }
+                process.exit(1);
+            });
+        }
     );
 
 program

--- a/packages/vitaminjs-build/config/build/webpack.config.client.js
+++ b/packages/vitaminjs-build/config/build/webpack.config.client.js
@@ -30,7 +30,10 @@ export default function clientConfig(options) {
                 'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
             }),
             options.hot && new webpack.NoEmitOnErrorsPlugin(),
-            !options.dev && new webpack.optimize.UglifyJsPlugin({ minimize: true }),
+            !options.dev && new webpack.optimize.UglifyJsPlugin({
+                sourceMap: options.withSourceMaps,
+                minimize: true
+            }),
             options.client.serviceWorker && new ServiceWorkerWebpackPlugin({
                 // FIXME Move resolving with other config props
                 entry: resolveConfigModule(options.client.serviceWorker),

--- a/packages/vitaminjs-build/config/build/webpack.config.common.js
+++ b/packages/vitaminjs-build/config/build/webpack.config.common.js
@@ -64,7 +64,7 @@ export function config(options) {
         'postcss-loader',
     ];
     return {
-        devtool: options.dev && 'source-map',
+        devtool: (options.withSourceMaps || options.dev) && 'source-map',
         output: {
             pathinfo: options.dev,
             publicPath: `${options.publicPath}/`,


### PR DESCRIPTION
This commit add a new flag to `vitamin-build` : --with-source-maps which allows source-maps to be
created either in development or in production. If not specified, source-maps won't be generated.