### PR TITLE
Drop syntax features not supported by node 6

### DIFF
--- a/packages/vitaminjs-build/bin/vitamin.js
+++ b/packages/vitaminjs-build/bin/vitamin.js
@@ -31,7 +31,7 @@ const clean = () => new Promise((resolve, reject) => {
     const config = parseConfig();
     return rimraf(
         path.join(config.server.buildPath, '*'),
-        (err, data) => (!err ? resolve(data) : reject(err)),
+        (err, data) => (!err ? resolve(data) : reject(err))
     );
 });
 
@@ -39,7 +39,7 @@ const checkHot = (hot) => {
     if (hot && !DEV) {
         console.log(chalk.yellow(
             '[WARNING]: Hot module reload option ignored in production environment.\n' +
-            '(based on your NODE_ENV variable)\n',
+            '(based on your NODE_ENV variable)\n'
         ));
         /* eslint no-param-reassign: 0 */
         return false;
@@ -75,7 +75,7 @@ const createCompiler = (webpackConfig, message, options) => {
     if (process.stdout.isTTY) {
         const bar = new ProgressBar(
             `${chalk.blue(`${symbols.clock} Building ${message}...`)} :percent [:bar]`,
-            { incomplete: ' ', total: 60, clear: true, stream: process.stdout },
+            { incomplete: ' ', total: 60, clear: true, stream: process.stdout }
         );
         compiler.apply(new ProgressPlugin((percentage, msg) => {
             bar.update(percentage, { msg });
@@ -91,11 +91,12 @@ const createCompiler = (webpackConfig, message, options) => {
 const commonBuild = (createWebpackConfig, message, options, hotCallback, restartServer) => {
     const createCompilerCommonBuild = () => {
         const config = parseConfig();
-        const webpackConfig = createWebpackConfig({
-            ...options,
-            dev: DEV,
-            ...config,
-        });
+        const webpackConfig = createWebpackConfig(Object.assign(
+            {},
+            options,
+            { dev: DEV },
+            config
+        ));
         const compiler = createCompiler(webpackConfig, message, options);
         return { compiler, config };
     };
@@ -132,7 +133,7 @@ const build = (options, hotCallback, restartServer) => (options.hot ?
         `server bundle ${chalk.bold('[hot]')}`,
         options,
         hotCallback,
-        restartServer,
+        restartServer
     )
     :
     commonBuild(webpackConfigClient, 'client bundle(s)', options)
@@ -140,7 +141,11 @@ const build = (options, hotCallback, restartServer) => (options.hot ?
             webpackConfigServer, 'server bundle...',
             // Cannot build in parallel because server-side rendering
             // needs client bundle name in the html layout for script path
-            { ...options, assetsByChunkName: buildStats.toJson().assetsByChunkName },
+            Object.assign(
+                {},
+                options,
+                { assetsByChunkName: buildStats.toJson().assetsByChunkName }
+            )
         ))
         .then(({ config }) => restartServer && restartServer(config))
 );
@@ -155,7 +160,7 @@ const test = ({ hot, runner, runnerArgs }) => {
         console.log(chalk.blue(`${symbols.clock} Launching tests...`));
         const serverFile = path.join(
             config.server.buildPath,
-            'tests',
+            'tests'
         );
         spawn(`${runner} ${serverFile} ${runnerArgs}`, { stdio: 'pipe' });
     };
@@ -168,7 +173,7 @@ const serve = (config) => {
     process.stdout.write(chalk.blue(`${symbols.clock} Launching server...`));
     const serverFile = path.join(
         config.server.buildPath,
-        config.server.filename,
+        config.server.filename
     );
     try {
         fs.accessSync(serverFile, fs.F_OK);
@@ -178,7 +183,7 @@ const serve = (config) => {
         console.error(chalk.red(
             `\n\nCannot access the server bundle file. Make sure you built
 the app with \`vitamin build\` before calling \`vitamin serve\`, and that
-the file is accessible by the current user`,
+the file is accessible by the current user`
         ));
         process.exit(1);
     }
@@ -310,7 +315,7 @@ program
                 '- If it occurs during initialization, it is probably an error in your app. Check the' +
                 ' stacktrace for more info (`ReferenceError` are pretty common)\n' +
                 '- If your positive it\'s not any of that, it might be because of a problem with ' +
-                'vitaminjs itself. Please report it to https://github.com/Evaneos/vitaminjs/issues',
+                'vitaminjs itself. Please report it to https://github.com/Evaneos/vitaminjs/issues'
             ));
             process.exit(1);
         });

--- a/packages/vitaminjs-build/config/build/webpack.config.common.js
+++ b/packages/vitaminjs-build/config/build/webpack.config.common.js
@@ -48,18 +48,23 @@ function config(options) {
         },
         {
             loader: 'css-loader',
-            options: {
-                minimize: !options.dev,
-                discardComments: {
-                    removeAll: !options.dev,
-                },
-                importLoaders: 1,
-                ...(modules ? {
-                    localIdentName: options.dev ?
-                        '[name]__[local]___[hash:base64:5]' : '[hash:base64]',
-                    modules: true,
-                } : {}),
-            },
+            options: (() => {
+                const cssOptions = {
+                    minimize: !options.dev,
+                    discardComments: {
+                        removeAll: !options.dev,
+                    },
+                    importLoaders: 1,
+                };
+                if (modules) {
+                    Object.assign(cssOptions, {
+                        localIdentName: options.dev ?
+                            '[name]__[local]___[hash:base64:5]' : '[hash:base64]',
+                        modules: true,
+                    });
+                }
+                return cssOptions;
+            })(),
         },
         'postcss-loader',
     ];
@@ -110,10 +115,11 @@ function config(options) {
         },
         cache: options.hot,
         resolve: {
-            alias: {
-                ...options.moduleMap,
-                __vitamin_runtime_config__: require.resolve('../runtimeConfig'),
-            },
+            alias: Object.assign(
+                {},
+                options.moduleMap,
+                { __vitamin_runtime_config__: require.resolve('../runtimeConfig') }
+            ),
             // Commmented out beause absolute paths were opting out of node resolve algorithm
             // modules: MODULES_DIRECTORIES,
             extensions: ['.js', '.jsx', '.json', '.css'],

--- a/packages/vitaminjs-build/config/index.js
+++ b/packages/vitaminjs-build/config/index.js
@@ -129,7 +129,7 @@ exports.default = () => {
         ['server', 'buildPath'],
         ['client', 'buildPath'],
     ].forEach(
-        path => updatePath(path, resolveConfigPath, config),
+        path => updatePath(path, resolveConfigPath, config)
     );
 
     // Prepend / to publicPath and basePath if necessary
@@ -137,7 +137,7 @@ exports.default = () => {
         ((path.startsWith('/') || path.match(/^(http|\/|$)/)) ? '' : '/') + path
     );
     [['publicPath'], ['basePath']].forEach(
-        path => updatePath(path, prependSlash, config),
+        path => updatePath(path, prependSlash, config)
     );
 
     // If public path is not absolute url, prepend basePath
@@ -145,8 +145,7 @@ exports.default = () => {
         (!publicPath.match(/^(http|\/\/)/) ? config.basePath.replace(/\/$/, '') : '') + config.publicPath,
     config);
 
-    return {
-        ...config,
-        moduleMap,
-    };
+    config.moduleMap = moduleMap;
+
+    return config;
 };

--- a/packages/vitaminjs-runtime/src/server/middlewares/router.js
+++ b/packages/vitaminjs-runtime/src/server/middlewares/router.js
@@ -19,7 +19,7 @@ export default () => async (ctx, next) => {
                 } else if (redirectLocation) {
                     ctx.redirect(
                         (redirectLocation.basename || '') +
-                        redirectLocation.pathname + redirectLocation.search,
+                        redirectLocation.pathname + redirectLocation.search
                     );
                 } else if (renderProps) {
                     ctx.status = 200;
@@ -29,7 +29,7 @@ export default () => async (ctx, next) => {
                     ctx.body = 'Not found';
                 }
                 resolve();
-            },
+            }
         );
     });
 

--- a/packages/vitaminjs-runtime/src/server/server.js
+++ b/packages/vitaminjs-runtime/src/server/server.js
@@ -19,7 +19,7 @@ function appServer() {
     app.use(
         process.env.NODE_ENV === 'production' ? currentApp
             // ecapsulate app for hot reload
-            : (ctx, next) => currentApp(ctx, next),
+            : (ctx, next) => currentApp(ctx, next)
     );
     return app.callback();
 }
@@ -51,7 +51,7 @@ if (process.env.NODE_ENV !== 'production' && module.hot) {
                 clientBuilt = true;
                 process.stdout.write(
                     `\x1b[0G${chalk.green('\u2713')
-                    } Client bundle(s) successfully ${chalk.bold('built in memory')}\n\n`,
+                    } Client bundle(s) successfully ${chalk.bold('built in memory')}\n\n`
                 );
             },
             serverSideRender: true,

--- a/packages/vitaminjs-runtime/src/shared/store.js
+++ b/packages/vitaminjs-runtime/src/shared/store.js
@@ -18,7 +18,7 @@ export function create(history, reducers, middlewares, initialState) {
     const createStoreWithMiddleware = compose(
         applyMiddleware(...middlewares, thunk, routerMiddleware(history)),
         ...devEnhancers,
-        ...appEnhancers,
+        ...appEnhancers
     )(createStore);
 
     const rootReducer = createRootReducer(reducers);


### PR DESCRIPTION
This removes some syntax features:
- object spread operator (`...`) (vitamin-build only)
- trailing commas in functions (everywhere to keep coherent linting rules)

This fixes a regression introduced by the removal of the require hook in #410.
